### PR TITLE
Add AI/ML API integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
 > [!NOTE]
 > This repository contains the core E2B SDK that's used in our main [E2B Code Interpreter SDK](https://github.com/e2b-dev/code-interpreter).
 
+E2B works with any LLM that supports tool use. You can connect providers like OpenAI,
+Anthropic, Mistral, Groq, or custom OpenAI-compatible APIs such as the **AI/ML API**.
+
 ## Run your first Sandbox
 
 ### 1. Install SDK

--- a/apps/web/src/app/(docs)/docs/quickstart/connect-llms/page.mdx
+++ b/apps/web/src/app/(docs)/docs/quickstart/connect-llms/page.mdx
@@ -8,6 +8,7 @@ If the LLM doesn't support tool use, you can, for example, prompt the LLM to out
 - [Anthropic](#anthropic)
 - [Mistral](#mistral)
 - [Groq](#groq)
+- [AI/ML API](#ai-ml-api)
 - [Vercel AI SDK](#vercel-ai-sdk)
 - [CrewAI](#crewai)
 - [LangChain](#langchain)
@@ -412,6 +413,41 @@ with Sandbox() as sandbox:
 
 print(result)
 
+```
+</CodeGroup>
+
+## AI/ML API
+
+<CodeGroup>
+```python
+# pip install openai e2b-code-interpreter
+import os
+from openai import OpenAI
+from e2b_code_interpreter import Sandbox
+
+# Create AI/ML API client using OpenAI-compatible endpoint
+client = OpenAI(base_url="https://api.aimlapi.com/v1", api_key=os.environ["AIML_API_KEY"])
+system_prompt = "You are a helpful assistant that can execute python code in a Jupyter notebook. Only respond with the code to be executed and nothing else. Strip backticks in code blocks."
+prompt = "Calculate how many r's are in the word 'strawberry'"
+
+# Send the prompt to the model
+response = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=[
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+)
+
+# Extract the code from the response
+code = response.choices[0].message.content
+
+# Execute code in E2B Sandbox
+with Sandbox() as sandbox:
+    execution = sandbox.run_code(code)
+    result = execution.text
+
+print(result)
 ```
 </CodeGroup>
 


### PR DESCRIPTION
## Summary
- document how to connect the AI/ML API using the OpenAI-compatible endpoint
- mention AI/ML API in the README
- clean up the OpenAI example

## Testing
- `pnpm test` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685a9fc57b1883298f44fce8da7961f8